### PR TITLE
fedora: fix build

### DIFF
--- a/build.mk
+++ b/build.mk
@@ -8,6 +8,6 @@ build-ebpf-object:
 	sudo docker run --rm -e DEBUG=$(DEBUG) \
 		-e DISTRO=$(DISTRO) \
 		-v $(PWD):/src:ro \
-		-v $(PWD)/ebpf/$(DISTRO):/dist/ kinvolk/ebpf-kernel-$(DISTRO)-builder \
+		-v $(PWD)/ebpf:/dist/ kinvolk/ebpf-kernel-$(DISTRO)-builder \
 		make -f ebpf.mk build
 	sudo chown -R $(UID):$(UID) ebpf

--- a/ebpf.mk
+++ b/ebpf.mk
@@ -1,6 +1,7 @@
 LINUX_VERSION=$(shell make -f environments/$(DISTRO).mk linux-version)
 LINUX_HEADERS=$(shell make -f environments/$(DISTRO).mk linux-headers)
-DEST_DIR=/dist/$(shell uname -m)/$(LINUX_VERSION)
+DISTRO_ID=$(shell make -f environments/$(DISTRO).mk distro-id)
+DEST_DIR=/dist/$(DISTRO_ID)/$(shell uname -m)/$(LINUX_VERSION)
 
 build:
 	@mkdir -p "$(DEST_DIR)"

--- a/environments/arch.mk
+++ b/environments/arch.mk
@@ -9,3 +9,6 @@ linux-version:
 
 linux-headers:
 	@pacman -Q linux-headers | awk '{print "/usr/lib/modules/"$$2"-ARCH/build"}'
+
+distro-id:
+	@grep ^ID= /etc/os-release  | awk -F= '{print $$2}'

--- a/environments/debian-testing.mk
+++ b/environments/debian-testing.mk
@@ -9,3 +9,6 @@ linux-version:
 
 linux-headers:
 	@dpkg -l | awk '/linux-headers-.*-(common|amd64) .*/{print "/usr/src/"$$2}'
+
+distro-id:
+	@grep ^ID= /etc/os-release  | awk -F= '{print $$2}'

--- a/environments/fedora-24.mk
+++ b/environments/fedora-24.mk
@@ -5,7 +5,10 @@ DISTRO=fedora-24
 build: build-docker-image build-ebpf-object
 
 linux-version:
-	@dnf list kernel-devel | awk '/^kernel-devel\..*/{print $$2}'
+	@dnf list kernel-devel | awk '/^kernel-devel\..*/{print $$2".x86_64"}'
 
 linux-headers:
 	@dnf list kernel-devel | awk '/^kernel-devel\..*/{print "/usr/src/kernels/"$$2".x86_64"}'
+
+distro-id:
+	@grep ^ID= /etc/os-release  | awk -F= '{print $$2}'


### PR DESCRIPTION
"uname -r" reports this for me:
4.8.10-200.fc24.x86_64

The x86_64 part was missing

Also, the distro name is now based on the ID field in /etc/os-release
(i.e. "fedora" instead of "fedora-24"). This will allow Scope to detect
the distribution.

The distro name has a specific Makefile rule "distro-id" in each
environments/*.mk. For now, this is the same parsing of /etc/os-release
but it will be different in CoreOS because CoreOS will not be build from
a coreos container but maybe a fedora container.

@iaguis @schu 