### PR TITLE
Fix arch builder

### DIFF
--- a/environments/arch.mk
+++ b/environments/arch.mk
@@ -11,4 +11,4 @@ linux-headers:
 	@pacman -Q linux-headers | awk '{print "/usr/lib/modules/"$$2"-ARCH/build"}'
 
 distro-id:
-	@grep ^ID= /etc/os-release  | awk -F= '{print $$2}'
+	@grep ^ID= /usr/lib/os-release  | awk -F= '{print $$2}'


### PR DESCRIPTION
The image `base/archlinux` does not have `/etc/os-release`
so we use `/usr/lib/os-release`.

The file /etc/os-release takes precedence over /usr/lib/os-release.
Applications should check for the former, and exclusively use its data if it exists,
and only fall back to /usr/lib/os-release if it is missing.
Source: https://www.freedesktop.org/software/systemd/man/os-release.html

We should fallback instead of checking directly `/usr/lib/os-release`
but for now is good enough.

/cc @alban @iaguis @schu 