### PR TITLE
Put common Go code into packages under pkg/...

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,25 @@
-This is an experiment under development to build eBPF tcptracer objects
-for different distributions and kernel versions.
+# tcptracer-bpf
 
-Goal is to be able to load the compiled ebpf object files without dependencies
-on kernel headers in production, so [bcc](https://github.com/iovisor/bcc)
-cannot be used in this case.
+tcptracer-bpf is an eBPF program using kprobes to trace TCP events. It's
+built as an object file that can be used with the [gobpf elf package](https://github.com/iovisor/gobpf).
+It does not have any run-time dependencies and adapts to the currently running
+kernel at run-time. It does not use [bcc](https://github.com/iovisor/bcc)
+because that would introduce a run-time dependency on the kernel headers.
 
-The generated object files can be used and tested with the
-[gobpf-elf-loader](https://github.com/kinvolk/gobpf-elf-loader).
+See `tests/tracer.go` for an example how to use tcptracer-bpf with gobpf.
 
-## Usage
+## Build the elf object
 
 ```
-make <environment> # build an environment, e.g.
-make fedora-24
+make
+```
+
+The object file can be found in `ebpf/ebpf.o`.
+
+## Test
+
+```
+cd tests
+make
+sudo ./run
 ```

--- a/pkg/byteorder/byteorder.go
+++ b/pkg/byteorder/byteorder.go
@@ -1,0 +1,21 @@
+package byteorder
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+var Host binary.ByteOrder
+
+// In lack of binary.HostEndian ...
+func init() {
+	var i int32 = 0x01020304
+	u := unsafe.Pointer(&i)
+	pb := (*byte)(u)
+	b := *pb
+	if b == 0x04 {
+		Host = binary.LittleEndian
+	} else {
+		Host = binary.BigEndian
+	}
+}

--- a/pkg/offsetguess/offsetguess.go
+++ b/pkg/offsetguess/offsetguess.go
@@ -1,0 +1,285 @@
+// +build linux
+
+package offsetguess
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/iovisor/gobpf/elf"
+
+	"github.com/kinvolk/tcptracer-bpf/pkg/byteorder"
+)
+
+type tcpTracerState uint64
+
+const (
+	uninitialized tcpTracerState = iota
+	checking
+	checked
+	ready
+)
+
+type guessWhat uint64
+
+const (
+	guessSaddr guessWhat = iota
+	guessDaddr
+	guessFamily
+	guessSport
+	guessDport
+	guessNetns
+	guessDaddrIPv6
+)
+
+type tcpTracerStatus struct {
+	status          tcpTracerState
+	pidTgid         uint64
+	what            guessWhat
+	offsetSaddr     uint64
+	offsetDaddr     uint64
+	offsetSport     uint64
+	offsetDport     uint64
+	offsetNetns     uint64
+	offsetIno       uint64
+	offsetFamily    uint64
+	offsetDaddrIPv6 uint64
+	err             byte
+	saddr           uint32
+	daddr           uint32
+	sport           uint16
+	dport           uint16
+	netns           uint32
+	family          uint16
+	daddrIPv6       [4]uint32
+}
+
+func listen(url, netType string, finish chan struct{}) {
+	l, err := net.Listen(netType, url)
+	if err != nil {
+		panic(err)
+	}
+	select {
+	case <-finish:
+		l.Close()
+		return
+	}
+}
+
+func compareIPv6(a, b [4]uint32) bool {
+	for i := 0; i < 4; i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func ownNetNS() (uint64, error) {
+	var s syscall.Stat_t
+	if err := syscall.Stat("/proc/self/ns/net", &s); err != nil {
+		return 0, err
+	}
+	return s.Ino, nil
+}
+
+func ipFromUint32Arr(ipv6Addr [4]uint32) net.IP {
+	buf := make([]byte, 16)
+	for i := 0; i < 16; i++ {
+		buf[i] = *(*byte)(unsafe.Pointer((uintptr(unsafe.Pointer(&ipv6Addr[0])) + uintptr(i))))
+	}
+	return net.IP(buf)
+}
+
+func htons(a uint16) uint16 {
+	arr := make([]byte, 2)
+	binary.BigEndian.PutUint16(arr, a)
+	return byteorder.Host.Uint16(arr)
+}
+
+// Guess expects elf.Module to hold a tcptracer-bpf object and initializes
+// the tracer by guessing the right kernel struct offsets. Results are
+// stored in the `tcptracer_status` map as used by the module.
+func Guess(b *elf.Module) error {
+	listenIP := "127.0.0.2"
+	listenPort := uint16(9091)
+	bindAddress := fmt.Sprintf("%s:%d", listenIP, listenPort)
+
+	finish := make(chan struct{})
+	go listen(bindAddress, "tcp4", finish)
+	defer close(finish)
+	time.Sleep(300 * time.Millisecond)
+
+	currentNetns, err := ownNetNS()
+	if err != nil {
+		return fmt.Errorf("error getting current netns: %v", err)
+	}
+
+	mp := b.Map("tcptracer_status")
+
+	var zero uint64
+	pidTgid := uint64(os.Getpid()<<32 | syscall.Gettid())
+
+	status := tcpTracerStatus{
+		status:  checking,
+		pidTgid: pidTgid,
+	}
+
+	err = b.UpdateElement(mp, unsafe.Pointer(&zero), unsafe.Pointer(&status), 0)
+	if err != nil {
+		return fmt.Errorf("error initializing tcptracer_status map: %v", err)
+	}
+
+	dport := htons(listenPort)
+
+	// 127.0.0.1
+	saddr := 0x0100007F
+	// 127.0.0.2
+	daddr := 0x0200007F
+	// will be set later
+	sport := 0
+	netns := uint32(currentNetns)
+	family := syscall.AF_INET
+
+	for status.status != ready {
+		var daddrIPv6 [4]uint32
+
+		daddrIPv6[0] = rand.Uint32()
+		daddrIPv6[1] = rand.Uint32()
+		daddrIPv6[2] = rand.Uint32()
+		daddrIPv6[3] = rand.Uint32()
+
+		ip := ipFromUint32Arr(daddrIPv6)
+
+		if status.what != guessDaddrIPv6 {
+			conn, err := net.Dial("tcp4", bindAddress)
+			if err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+
+			sport, err = strconv.Atoi(strings.Split(conn.LocalAddr().String(), ":")[1])
+			if err != nil {
+				return fmt.Errorf("error converting source port: %v", err)
+			}
+
+			sport = int(htons(uint16(sport)))
+
+			// set SO_LINGER to 0 so the connection state after closing is
+			// CLOSE instead of TIME_WAIT. In this way, they will disappear
+			// from the conntrack table after around 10 seconds instead of 2
+			// minutes
+			if tcpConn, ok := conn.(*net.TCPConn); ok {
+				tcpConn.SetLinger(0)
+			} else {
+				return fmt.Errorf("not a tcp connection unexpectedly")
+			}
+
+			conn.Close()
+		} else {
+			conn, err := net.Dial("tcp6", fmt.Sprintf("[%s]:9092", ip))
+			if err == nil {
+				conn.Close()
+			}
+		}
+
+		err = b.LookupElement(mp, unsafe.Pointer(&zero), unsafe.Pointer(&status))
+		if err != nil {
+			return fmt.Errorf("error reading tcptracer_status: %v", err)
+		}
+
+		if status.status == checked {
+			switch status.what {
+			case guessSaddr:
+				if status.saddr == uint32(saddr) {
+					status.what++
+					status.status = checking
+				} else {
+					status.offsetSaddr++
+					status.status = checking
+					status.saddr = uint32(saddr)
+				}
+			case guessDaddr:
+				if status.daddr == uint32(daddr) {
+					status.what++
+					status.status = checking
+				} else {
+					status.offsetDaddr++
+					status.status = checking
+					status.daddr = uint32(daddr)
+				}
+			case guessFamily:
+				if status.family == uint16(family) {
+					status.what++
+					status.status = checking
+					// we know the sport ((struct inet_sock)->inet_sport) is
+					// after the family field, so we start from there
+					status.offsetSport = status.offsetFamily
+				} else {
+					status.offsetFamily++
+					status.status = checking
+				}
+			case guessSport:
+				if status.sport == uint16(sport) {
+					status.what++
+					status.status = checking
+				} else {
+					status.offsetSport++
+					status.status = checking
+				}
+			case guessDport:
+				if status.dport == dport {
+					status.what++
+					status.status = checking
+				} else {
+					status.offsetDport++
+					status.status = checking
+				}
+			case guessNetns:
+				if status.netns == netns {
+					status.what++
+					status.status = checking
+				} else {
+					status.offsetIno++
+					// go to the next offsetNetns if we get an error
+					if status.err != 0 || status.offsetIno >= 200 {
+						status.offsetIno = 0
+						status.offsetNetns++
+					}
+					status.status = checking
+				}
+			case guessDaddrIPv6:
+				if compareIPv6(status.daddrIPv6, daddrIPv6) {
+					status.what++
+					status.status = ready
+				} else {
+					status.offsetDaddrIPv6++
+					status.status = checking
+				}
+			default:
+				return fmt.Errorf("unexpected field")
+			}
+		}
+
+		err = b.UpdateElement(mp, unsafe.Pointer(&zero), unsafe.Pointer(&status), 0)
+		if err != nil {
+			return fmt.Errorf("error updating tcptracer_status: %v", err)
+		}
+
+		if status.offsetSaddr >= 200 || status.offsetDaddr >= 200 ||
+			status.offsetSport >= 2000 || status.offsetDport >= 200 ||
+			status.offsetNetns >= 200 || status.offsetFamily >= 200 ||
+			status.offsetDaddrIPv6 >= 200 {
+			return fmt.Errorf("overflow, bailing out")
+		}
+	}
+
+	return nil
+}

--- a/tests/tracer.go
+++ b/tests/tracer.go
@@ -4,17 +4,14 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"math/rand"
 	"net"
 	"os"
 	"os/signal"
-	"strconv"
-	"strings"
-	"syscall"
-	"time"
-	"unsafe"
 
 	"github.com/iovisor/gobpf/elf"
+
+	"github.com/kinvolk/tcptracer-bpf/pkg/byteorder"
+	"github.com/kinvolk/tcptracer-bpf/pkg/offsetguess"
 )
 
 type EventType uint32
@@ -69,287 +66,6 @@ type tcpEventV6 struct {
 	SPort  uint16
 	DPort  uint16
 	NetNS  uint32
-}
-
-type tcpTracerState uint64
-
-const (
-	uninitialized tcpTracerState = iota
-	checking
-	checked
-	ready
-)
-
-type guessWhat uint64
-
-const (
-	guessSaddr guessWhat = iota
-	guessDaddr
-	guessFamily
-	guessSport
-	guessDport
-	guessNetns
-	guessDaddrIPv6
-)
-
-type tcpTracerStatus struct {
-	status          tcpTracerState
-	pidTgid         uint64
-	what            guessWhat
-	offsetSaddr     uint64
-	offsetDaddr     uint64
-	offsetSport     uint64
-	offsetDport     uint64
-	offsetNetns     uint64
-	offsetIno       uint64
-	offsetFamily    uint64
-	offsetDaddrIPv6 uint64
-	err             byte
-	saddr           uint32
-	daddr           uint32
-	sport           uint16
-	dport           uint16
-	netns           uint32
-	family          uint16
-	daddrIPv6       [4]uint32
-}
-
-var byteOrder binary.ByteOrder
-
-// In lack of binary.HostEndian ...
-func init() {
-	var i int32 = 0x01020304
-	u := unsafe.Pointer(&i)
-	pb := (*byte)(u)
-	b := *pb
-	if b == 0x04 {
-		byteOrder = binary.LittleEndian
-	} else {
-		byteOrder = binary.BigEndian
-	}
-}
-
-func listen(url, netType string, finish chan struct{}) {
-	l, err := net.Listen(netType, url)
-	if err != nil {
-		fmt.Println("Error listening:", err.Error())
-		os.Exit(1)
-	}
-	select {
-	case <-finish:
-		l.Close()
-		return
-	}
-}
-
-func compareIPv6(a, b [4]uint32) bool {
-	for i := 0; i < 4; i++ {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func ownNetNS() (uint64, error) {
-	var s syscall.Stat_t
-	if err := syscall.Stat("/proc/self/ns/net", &s); err != nil {
-		return 0, err
-	}
-	return s.Ino, nil
-}
-
-func ipFromUint32Arr(ipv6Addr [4]uint32) net.IP {
-	buf := make([]byte, 16)
-	for i := 0; i < 16; i++ {
-		buf[i] = *(*byte)(unsafe.Pointer((uintptr(unsafe.Pointer(&ipv6Addr[0])) + uintptr(i))))
-	}
-	return net.IP(buf)
-}
-
-func htons(a uint16) uint16 {
-	arr := make([]byte, 2)
-	binary.BigEndian.PutUint16(arr, a)
-	return byteOrder.Uint16(arr)
-}
-
-func guessOffsets(b *elf.Module) error {
-	listenIP := "127.0.0.2"
-	listenPort := uint16(9091)
-	bindAddress := fmt.Sprintf("%s:%d", listenIP, listenPort)
-
-	finish := make(chan struct{})
-	go listen(bindAddress, "tcp4", finish)
-	time.Sleep(300 * time.Millisecond)
-
-	currentNetns, err := ownNetNS()
-	if err != nil {
-		return fmt.Errorf("error getting current netns: %v", err)
-		os.Exit(1)
-	}
-
-	mp := b.Map("tcptracer_status")
-
-	var zero uint64
-	pidTgid := uint64(os.Getpid()<<32 | syscall.Gettid())
-
-	status := tcpTracerStatus{
-		status:  checking,
-		pidTgid: pidTgid,
-	}
-
-	err = b.UpdateElement(mp, unsafe.Pointer(&zero), unsafe.Pointer(&status), 0)
-	if err != nil {
-		return fmt.Errorf("error: %v", err)
-	}
-
-	dport := htons(listenPort)
-
-	// 127.0.0.1
-	saddr := 0x0100007F
-	// 127.0.0.2
-	daddr := 0x0200007F
-	// will be set later
-	sport := 0
-	netns := uint32(currentNetns)
-	family := syscall.AF_INET
-
-	for status.status != ready {
-		var daddrIPv6 [4]uint32
-
-		daddrIPv6[0] = rand.Uint32()
-		daddrIPv6[1] = rand.Uint32()
-		daddrIPv6[2] = rand.Uint32()
-		daddrIPv6[3] = rand.Uint32()
-
-		ip := ipFromUint32Arr(daddrIPv6)
-
-		if status.what != guessDaddrIPv6 {
-			conn, err := net.Dial("tcp4", bindAddress)
-			if err != nil {
-				fmt.Printf("error: %v\n", err)
-			}
-
-			sport, err = strconv.Atoi(strings.Split(conn.LocalAddr().String(), ":")[1])
-			if err != nil {
-				return fmt.Errorf("error: %v", err)
-			}
-
-			sport = int(htons(uint16(sport)))
-
-			// set SO_LINGER to 0 so the connection state after closing is
-			// CLOSE instead of TIME_WAIT. In this way, they will disappear
-			// from the conntrack table after around 10 seconds instead of 2
-			// minutes
-			if tcpConn, ok := conn.(*net.TCPConn); ok {
-				tcpConn.SetLinger(0)
-			} else {
-				panic("not a tcp connection")
-			}
-
-			conn.Close()
-		} else {
-			conn, err := net.Dial("tcp6", fmt.Sprintf("[%s]:9092", ip))
-			if err == nil {
-				conn.Close()
-			}
-		}
-
-		err = b.LookupElement(mp, unsafe.Pointer(&zero), unsafe.Pointer(&status))
-		if err != nil {
-			return fmt.Errorf("error: %v", err)
-		}
-
-		if status.status == checked {
-			switch status.what {
-			case guessSaddr:
-				if status.saddr == uint32(saddr) {
-					status.what++
-					status.status = checking
-				} else {
-					status.offsetSaddr++
-					status.status = checking
-					status.saddr = uint32(saddr)
-				}
-			case guessDaddr:
-				if status.daddr == uint32(daddr) {
-					status.what++
-					status.status = checking
-				} else {
-					status.offsetDaddr++
-					status.status = checking
-					status.daddr = uint32(daddr)
-				}
-			case guessFamily:
-				if status.family == uint16(family) {
-					status.what++
-					status.status = checking
-					// we know the sport ((struct inet_sock)->inet_sport) is
-					// after the family field, so we start from there
-					status.offsetSport = status.offsetFamily
-				} else {
-					status.offsetFamily++
-					status.status = checking
-				}
-			case guessSport:
-				if status.sport == uint16(sport) {
-					status.what++
-					status.status = checking
-				} else {
-					status.offsetSport++
-					status.status = checking
-				}
-			case guessDport:
-				if status.dport == dport {
-					status.what++
-					status.status = checking
-				} else {
-					status.offsetDport++
-					status.status = checking
-				}
-			case guessNetns:
-				if status.netns == netns {
-					status.what++
-					status.status = checking
-				} else {
-					status.offsetIno++
-					// go to the next offsetNetns if we get an error
-					if status.err != 0 || status.offsetIno >= 200 {
-						status.offsetIno = 0
-						status.offsetNetns++
-					}
-					status.status = checking
-				}
-			case guessDaddrIPv6:
-				if compareIPv6(status.daddrIPv6, daddrIPv6) {
-					status.what++
-					status.status = ready
-				} else {
-					status.offsetDaddrIPv6++
-					status.status = checking
-				}
-			default:
-				return fmt.Errorf("Uh, oh!")
-			}
-		}
-
-		err = b.UpdateElement(mp, unsafe.Pointer(&zero), unsafe.Pointer(&status), 0)
-		if err != nil {
-			return fmt.Errorf("error: %v", err)
-		}
-
-		if status.offsetSaddr >= 200 || status.offsetDaddr >= 200 ||
-			status.offsetSport >= 2000 || status.offsetDport >= 200 ||
-			status.offsetNetns >= 200 || status.offsetFamily >= 200 ||
-			status.offsetDaddrIPv6 >= 200 {
-			fmt.Fprintf(os.Stderr, "overflow, bailing out!\n")
-			os.Exit(1)
-		}
-	}
-
-	close(finish)
-
-	return nil
 }
 
 var lastTimestampV4 uint64
@@ -457,7 +173,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := guessOffsets(b); err != nil {
+	if err := offsetguess.Guess(b); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
@@ -469,7 +185,7 @@ func main() {
 		var event tcpEventV4
 		for {
 			data := <-channelV4
-			err := binary.Read(bytes.NewBuffer(data), byteOrder, &event)
+			err := binary.Read(bytes.NewBuffer(data), byteorder.Host, &event)
 			if err != nil {
 				fmt.Printf("failed to decode received data: %s\n", err)
 				continue
@@ -482,7 +198,7 @@ func main() {
 		var event tcpEventV6
 		for {
 			data := <-channelV6
-			err := binary.Read(bytes.NewBuffer(data), byteOrder, &event)
+			err := binary.Read(bytes.NewBuffer(data), byteorder.Host, &event)
 			if err != nil {
 				fmt.Printf("failed to decode received data: %s\n", err)
 				continue


### PR DESCRIPTION
The `tracer` util in tests and users of tcptracer-bpf (e.g. scope) will
share the "guessing code", hence put it into a separate package to allow
re-use.