### PR TITLE
Add offsetguess_unsuported file

### DIFF
--- a/pkg/offsetguess/offsetguess_unsupported.go
+++ b/pkg/offsetguess/offsetguess_unsupported.go
@@ -1,0 +1,13 @@
+// +build !linux
+
+package offsetguess
+
+import (
+	"fmt"
+
+	"github.com/iovisor/gobpf/elf"
+)
+
+func Guess(b *elf.Module) error {
+	return fmt.Errorf("not supported on non-Linux systems")
+}


### PR DESCRIPTION
So other architectures can build this and get a proper error message.